### PR TITLE
Fix sound selection for pawns in the same cell and add null check for mod compat

### DIFF
--- a/Source/RealisticHumanSounds/SoundStarter_PlayOneShot.cs
+++ b/Source/RealisticHumanSounds/SoundStarter_PlayOneShot.cs
@@ -10,6 +10,11 @@ public static class SoundStarter_PlayOneShot
 {
     private static bool Prefix(ref SoundDef soundDef, ref SoundInfo info)
     {
+        if (soundDef == null)
+        {
+            return true;
+        }
+
         var map = info.Maker.Map;
         if (map == null)
         {
@@ -29,7 +34,7 @@ public static class SoundStarter_PlayOneShot
                         return false;
                     }
 
-                    pawn = info.Maker.Cell.GetFirstPawn(map);
+                    pawn = info.Maker.Thing as Pawn ?? info.Maker.Cell.GetFirstPawn(map);
                     if (pawn == null)
                     {
                         return false;
@@ -79,7 +84,7 @@ public static class SoundStarter_PlayOneShot
                         return false;
                     }
 
-                    pawn = info.Maker.Cell.GetFirstPawn(map);
+                    pawn = info.Maker.Thing as Pawn ?? info.Maker.Cell.GetFirstPawn(map);
                     if (pawn == null)
                     {
                         return false;


### PR DESCRIPTION
Directly check `info.Maker.Thing` before falling back to the tile search to ensure correct pawn selection when multiple pawns occupy the same cell. Added a null check for `soundDef` to prevent errors from other mods.